### PR TITLE
add prometheus endpoint `/metrics`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2823,6 +2823,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,6 +3383,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3778,12 +3793,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.5.0"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
+checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -4314,6 +4329,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ae428771d17306715c5091d446327d1cfdedc82185c65ba8423ab404e45bf10"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85b6f8152da6d7892ff1b7a1c0fa3f435e92b5918ad67035c3bb432111d9a29b"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.6.0",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b482df36c13dd1869d73d14d28cd4855fbd6cfc32294bee109908a9f4a4ed7"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.1",
+ "metrics",
+ "quanta",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4508,7 +4561,7 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "inventory",
  "oasgen-core",
  "oasgen-macro",
@@ -4529,7 +4582,7 @@ checksum = "997846b6e7ad93869478e6a9d7ea08dc7263ea787433b5f2670a1177f1e7c7ce"
 dependencies = [
  "axum",
  "http",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "inventory",
  "openapiv3-extended",
  "serde_json",
@@ -4602,7 +4655,7 @@ checksum = "756f9fddd9e5264d11c36c405a0b8a16bf7b2037bc8a424a0d14f74fd73dcb7f"
 dependencies = [
  "anyhow",
  "http",
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_json",
 ]
@@ -7328,6 +7381,8 @@ dependencies = [
  "anyhow",
  "axum",
  "clap",
+ "metrics",
+ "metrics-exporter-prometheus",
  "oasgen",
  "parity-scale-codec",
  "polkadot-sdk",
@@ -7550,6 +7605,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
+
+[[package]]
 name = "postgres-protocol"
 version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7737,6 +7798,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi",
+ "web-sys",
+ "winapi",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7794,6 +7870,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
  "rand_core",
+]
+
+[[package]]
+name = "raw-cpuid"
+version = "11.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ab240315c661615f2ee9f0f2cd32d5a7343a84d5ebcccb99d46e6637565e7b0"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -8815,7 +8900,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "itoa",
  "ryu",
  "serde",
@@ -8941,6 +9026,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"
@@ -10982,7 +11073,7 @@ version = "0.22.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583c44c02ad26b0c3f3066fe629275e50627026c51ac2e595cca4c230ce1ce1d"
 dependencies = [
- "indexmap 2.5.0",
+ "indexmap 2.6.0",
  "serde",
  "serde_spanned",
  "toml_datetime",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,8 @@ url = "2.5.3"
 
 # Web API
 axum = { version = "0.7.7",default-features = false, features = ["json"] }
+metrics = { version = "0.24", default-features = false }
+metrics-exporter-prometheus = { version = "0.16", default-features = false }
 
 # polkadot-sdk
 polkadot-sdk = { version = "0.7", features = ["sp-npos-elections", "pallet-election-provider-multi-phase"] }

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The tool is based on the subxt library and is written in Rust.
 - `GET /elections/failed` - Dump all failed elections.
 - `GET /slashed/` - Get all slashed solutions from the database in JSON format.
 - `GET /slashed/{n}` - Get the `n` most recent slashed solutions from the database in JSON format, n is a number.
+- `GET /metrics` - Fetch prometheus metrics.
 
 ## Roadmap
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,6 @@ use url::Url;
 
 const LOG_TARGET: &str = "polkadot-staking-miner-monitor";
 
-#[derive(Clone)]
-struct DbAndPrometheus {
-    db: db::Database,
-    prometheus: prometheus::PrometheusHandle,
-}
-
 #[derive(Debug, Clone, Parser)]
 #[clap(version = env!("CARGO_PKG_VERSION"))]
 struct Opt {
@@ -77,10 +71,7 @@ async fn main() -> anyhow::Result<()> {
     let (stop_tx, mut stop_rx) = mpsc::channel(1);
     let stop_tx2 = stop_tx.clone();
     let listener = tokio::net::TcpListener::bind(&listen_addr).await?;
-    let state = DbAndPrometheus {
-        db: db.clone(),
-        prometheus: prometheus.clone(),
-    };
+    let state = (db.clone(), prometheus.clone());
 
     tokio::spawn(async move {
         let app = oasgen::Server::axum()

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -17,6 +17,7 @@ pub(super) mod election_status {
 
     pub(super) const TARGET: &str = "polkadot_election_status";
     pub(super) const DESCRIPTION: &str = "The outcome of the most recent election represented as an integer. 0 if no election has occurred yet this is a placeholder value, 1 if the election succeeded based on an unsigned solution, 2 if the election succeeded based on a signed solution or 3 if the election failed.";
+    #[repr(u32)]
     pub(super) enum ElectionStatus {
         Unitialized = 0,
         Unsigned = 1,

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,29 +1,35 @@
+pub use election_status::record_election;
 pub use metrics_exporter_prometheus::PrometheusHandle;
 
-use crate::types::ElectionResult;
 use metrics::describe_gauge;
 use metrics_exporter_prometheus::PrometheusBuilder;
 
-const TARGET: &str = "polkadot_election_status";
-const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution, 2 if the election succeeded based on signed solution or 3 if no election has occurred yet";
-
-const FAILED: u32 = 0;
-const UNSIGNED: u32 = 1;
-const SIGNED: u32 = 2;
-const WAITING_FOR_ELECTION: u32 = 3;
-
 pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
     let handle = PrometheusBuilder::new().install_recorder()?;
-    describe_gauge!(TARGET, DESCRIPTION);
-    metrics::gauge!(TARGET, "handle" => "handle").set(WAITING_FOR_ELECTION);
+    describe_gauge!(election_status::TARGET, election_status::DESCRIPTION);
+    metrics::gauge!(election_status::TARGET)
+        .set(election_status::ElectionStatus::Unitialized as u32);
     Ok(handle)
 }
 
-pub fn record_election(election_result: &ElectionResult) {
-    let val = match election_result {
-        ElectionResult::Failed => FAILED,
-        ElectionResult::Unsigned => UNSIGNED,
-        ElectionResult::Signed(_) => SIGNED,
-    };
-    metrics::gauge!(TARGET, "handle" => "handle").set(val);
+pub(super) mod election_status {
+    use crate::types::ElectionResult;
+
+    pub(super) const TARGET: &str = "polkadot_election_status";
+    pub(super) const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution, 2 if the election succeeded based on signed solution or 3 if no election has occurred yet";
+    pub(super) enum ElectionStatus {
+        Unitialized = 0,
+        Unsigned = 1,
+        Signed = 2,
+        Failed = 3,
+    }
+
+    pub fn record_election(election_result: &ElectionResult) {
+        let val = match election_result {
+            ElectionResult::Failed => ElectionStatus::Failed,
+            ElectionResult::Unsigned => ElectionStatus::Unsigned,
+            ElectionResult::Signed(_) => ElectionStatus::Signed,
+        };
+        metrics::gauge!(TARGET).set(val as u32);
+    }
 }

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -16,7 +16,7 @@ pub(super) mod election_status {
     use crate::types::ElectionResult;
 
     pub(super) const TARGET: &str = "polkadot_election_status";
-    pub(super) const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution, 2 if the election succeeded based on signed solution or 3 if no election has occurred yet";
+    pub(super) const DESCRIPTION: &str = "The outcome of the most recent election represented as an integer. 0 if no election has occurred yet this is a placeholder value, 1 if the election succeeded based on an unsigned solution, 2 if the election succeeded based on a signed solution or 3 if the election failed.";
     pub(super) enum ElectionStatus {
         Unitialized = 0,
         Unsigned = 1,

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -1,0 +1,23 @@
+pub use metrics_exporter_prometheus::PrometheusHandle;
+
+use crate::types::ElectionResult;
+use metrics::describe_gauge;
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+const TARGET: &str = "polkadot_election_status";
+const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution and 2 if the election succeeded based on signed solution.";
+
+pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
+    let handle = PrometheusBuilder::new().install_recorder()?;
+    describe_gauge!(TARGET, DESCRIPTION);
+    Ok(handle)
+}
+
+pub fn record_election(election_result: &ElectionResult) {
+    let val = match election_result {
+        ElectionResult::Failed => 0,
+        ElectionResult::Unsigned => 1,
+        ElectionResult::Signed(_) => 2,
+    };
+    metrics::gauge!(TARGET, "handle" => "handle").set(val);
+}

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -5,17 +5,17 @@ use metrics::describe_gauge;
 use metrics_exporter_prometheus::PrometheusBuilder;
 
 const TARGET: &str = "polkadot_election_status";
-const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution and 2 if the election succeeded based on signed solution.";
+const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution, 2 if the election succeeded based on signed solution or 3 if no election has occurred yet";
 
 const FAILED: u32 = 0;
 const UNSIGNED: u32 = 1;
 const SIGNED: u32 = 2;
-const UNINITIALIZED: u32 = 3;
+const WAITING_FOR_ELECTION: u32 = 3;
 
 pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
     let handle = PrometheusBuilder::new().install_recorder()?;
     describe_gauge!(TARGET, DESCRIPTION);
-    metrics::gauge!(TARGET, "handle" => "handle").set(UNINITIALIZED);
+    metrics::gauge!(TARGET, "handle" => "handle").set(WAITING_FOR_ELECTION);
     Ok(handle)
 }
 

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -8,7 +8,7 @@ pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
     let handle = PrometheusBuilder::new().install_recorder()?;
     describe_gauge!(election_status::TARGET, election_status::DESCRIPTION);
     metrics::gauge!(election_status::TARGET)
-        .set(election_status::ElectionStatus::Unitialized as u32);
+        .set(election_status::ElectionStatus::Uninitialized as u32);
     Ok(handle)
 }
 
@@ -19,7 +19,7 @@ pub(super) mod election_status {
     pub(super) const DESCRIPTION: &str = "The outcome of the most recent election represented as an integer. 0 if no election has occurred yet this is a placeholder value, 1 if the election succeeded based on an unsigned solution, 2 if the election succeeded based on a signed solution or 3 if the election failed.";
     #[repr(u32)]
     pub(super) enum ElectionStatus {
-        Unitialized = 0,
+        Uninitialized = 0,
         Unsigned = 1,
         Signed = 2,
         Failed = 3,

--- a/src/prometheus.rs
+++ b/src/prometheus.rs
@@ -7,17 +7,23 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 const TARGET: &str = "polkadot_election_status";
 const DESCRIPTION: &str = "The outcome of the most recent election represented as a integer. 0 if the election failed, 1 if the election succeeded based on unsigned solution and 2 if the election succeeded based on signed solution.";
 
+const FAILED: u32 = 0;
+const UNSIGNED: u32 = 1;
+const SIGNED: u32 = 2;
+const UNINITIALIZED: u32 = 3;
+
 pub fn setup_metrics_recorder() -> anyhow::Result<PrometheusHandle> {
     let handle = PrometheusBuilder::new().install_recorder()?;
     describe_gauge!(TARGET, DESCRIPTION);
+    metrics::gauge!(TARGET, "handle" => "handle").set(UNINITIALIZED);
     Ok(handle)
 }
 
 pub fn record_election(election_result: &ElectionResult) {
     let val = match election_result {
-        ElectionResult::Failed => 0,
-        ElectionResult::Unsigned => 1,
-        ElectionResult::Signed(_) => 2,
+        ElectionResult::Failed => FAILED,
+        ElectionResult::Unsigned => UNSIGNED,
+        ElectionResult::Signed(_) => SIGNED,
     };
     metrics::gauge!(TARGET, "handle" => "handle").set(val);
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -2,7 +2,10 @@
 // This file is dual-licensed as Apache-2.0 or GPL-3.0.
 // see LICENSE for license details.
 
-use crate::db::{Database, Election, Slashed, Submission};
+use crate::{
+    db::{Election, Slashed, Submission},
+    DbAndPrometheus,
+};
 use axum::{
     extract::{Path, State},
     http::StatusCode,
@@ -15,17 +18,22 @@ type HttpError = (StatusCode, String);
 
 #[oasgen]
 pub async fn all_submissions(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Submission>>, HttpError> {
-    let submissions = db.get_all_submissions().await.map_err(internal_error)?;
+    let submissions = state
+        .db
+        .get_all_submissions()
+        .await
+        .map_err(internal_error)?;
     Ok(Json(submissions))
 }
 
 #[oasgen]
 pub async fn all_success_submissions(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Submission>>, HttpError> {
-    let submissions = db
+    let submissions = state
+        .db
         .get_all_success_submissions()
         .await
         .map_err(internal_error)?;
@@ -34,9 +42,10 @@ pub async fn all_success_submissions(
 
 #[oasgen]
 pub async fn all_failed_submissions(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Submission>>, HttpError> {
-    let submissions = db
+    let submissions = state
+        .db
         .get_all_failed_submissions()
         .await
         .map_err(internal_error)?;
@@ -45,9 +54,10 @@ pub async fn all_failed_submissions(
 
 #[oasgen]
 pub async fn all_unsigned_elections(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Election>>, HttpError> {
-    let elections = db
+    let elections = state
+        .db
         .get_all_unsigned_elections()
         .await
         .map_err(internal_error)?;
@@ -55,16 +65,19 @@ pub async fn all_unsigned_elections(
 }
 
 #[oasgen]
-pub async fn all_elections(State(db): State<Database>) -> Result<Json<Vec<Election>>, HttpError> {
-    let winners = db.get_all_elections().await.map_err(internal_error)?;
+pub async fn all_elections(
+    State(state): State<DbAndPrometheus>,
+) -> Result<Json<Vec<Election>>, HttpError> {
+    let winners = state.db.get_all_elections().await.map_err(internal_error)?;
     Ok(Json(winners))
 }
 
 #[oasgen]
 pub async fn all_failed_elections(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Election>>, HttpError> {
-    let elections = db
+    let elections = state
+        .db
         .get_all_failed_elections()
         .await
         .map_err(internal_error)?;
@@ -73,9 +86,10 @@ pub async fn all_failed_elections(
 
 #[oasgen]
 pub async fn all_signed_elections(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
 ) -> Result<Json<Vec<Election>>, HttpError> {
-    let elections = db
+    let elections = state
+        .db
         .get_all_signed_elections()
         .await
         .map_err(internal_error)?;
@@ -83,18 +97,21 @@ pub async fn all_signed_elections(
 }
 
 #[oasgen]
-pub async fn all_slashed(State(db): State<Database>) -> Result<Json<Vec<Slashed>>, HttpError> {
-    let slashed = db.get_all_slashed().await.map_err(internal_error)?;
+pub async fn all_slashed(
+    State(state): State<DbAndPrometheus>,
+) -> Result<Json<Vec<Slashed>>, HttpError> {
+    let slashed = state.db.get_all_slashed().await.map_err(internal_error)?;
     Ok(Json(slashed))
 }
 
 #[oasgen]
 pub async fn most_recent_submissions(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
     Path(n): Path<usize>,
 ) -> Result<Json<Vec<Submission>>, HttpError> {
     let n = into_non_zero_usize(n)?;
-    let submissions = db
+    let submissions = state
+        .db
         .get_most_recent_submissions(n)
         .await
         .map_err(internal_error)?;
@@ -103,11 +120,12 @@ pub async fn most_recent_submissions(
 
 #[oasgen]
 pub async fn most_recent_elections(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
     Path(n): Path<usize>,
 ) -> Result<Json<Vec<Election>>, HttpError> {
     let n = into_non_zero_usize(n)?;
-    let winners = db
+    let winners = state
+        .db
         .get_most_recent_elections(n)
         .await
         .map_err(internal_error)?;
@@ -116,15 +134,21 @@ pub async fn most_recent_elections(
 
 #[oasgen]
 pub async fn most_recent_slashed(
-    State(db): State<Database>,
+    State(state): State<DbAndPrometheus>,
     Path(n): Path<usize>,
 ) -> Result<Json<Vec<Slashed>>, HttpError> {
     let n = into_non_zero_usize(n)?;
-    let slashed = db
+    let slashed = state
+        .db
         .get_most_recent_slashed(n)
         .await
         .map_err(internal_error)?;
     Ok(Json(slashed))
+}
+
+#[oasgen]
+pub async fn metrics(State(state): State<DbAndPrometheus>) -> String {
+    state.prometheus.render()
 }
 
 // Convert a usize into a NonZeroUsize, returning an error if the value is zero.

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,7 +29,6 @@ pub type EpmPhase =
 pub use subxt::config::Header as HeaderT;
 pub type ExtrinsicDetails = subxt::blocks::ExtrinsicDetails<subxt::PolkadotConfig, ChainClient>;
 
-use core::fmt;
 use oasgen::OaSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
@@ -222,8 +221,8 @@ impl Chain {
     }
 }
 
-impl fmt::Display for Chain {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+impl std::fmt::Display for Chain {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -29,6 +29,7 @@ pub type EpmPhase =
 pub use subxt::config::Header as HeaderT;
 pub type ExtrinsicDetails = subxt::blocks::ExtrinsicDetails<subxt::PolkadotConfig, ChainClient>;
 
+use core::fmt;
 use oasgen::OaSchema;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::str::FromStr;
@@ -60,6 +61,16 @@ pub enum ElectionResult {
 impl Default for ElectionResult {
     fn default() -> Self {
         Self::Unsigned
+    }
+}
+
+impl std::fmt::Display for ElectionResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Signed(_) => f.write_str("signed"),
+            Self::Failed => f.write_str("failed"),
+            Self::Unsigned => f.write_str("unsigned"),
+        }
     }
 }
 
@@ -211,8 +222,8 @@ impl Chain {
     }
 }
 
-impl std::fmt::Display for Chain {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Display for Chain {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.as_str())
     }
 }


### PR DESCRIPTION
This PR adds a prometheus gauge named "polkadot_election_status" that represents the most recent election status.

The possible values are:
- 0: No election has occurred yet (used as default value at startup/restart etc)
- 1: Election completed by an unsigned solution
- 2: Election completed by a signed solution (from a staking-miner)
- 3: Election failed