### PR TITLE
ci: Upgrade actions/upload-artifact and actions/download-artifact to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
         run: mv ./target/release/polkadot-staking-miner-monitor .
 
       - name: Collect artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |
@@ -134,17 +134,13 @@ jobs:
     name: Test Docker image build
     if: ${{ github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
-    needs: [check-fmt,
-            check-clippy,
-            check-docs,
-            test,
-            build]
+    needs: [check-fmt, check-clippy, check-docs, test, build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: ./artifacts
@@ -172,17 +168,13 @@ jobs:
     if: ${{ github.ref == 'refs/heads/master' ||  github.ref_type == 'tag' }}
     runs-on: ubuntu-latest
     environment: master_and_tags
-    needs: [check-fmt,
-            check-clippy,
-            check-docs,
-            test,
-            build]
+    needs: [check-fmt, check-clippy, check-docs, test, build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: ./artifacts


### PR DESCRIPTION
Artifact actions v3 will be deprecated by December 5, 2024, updating them.

cc https://github.com/paritytech/ci_cd/issues/1078